### PR TITLE
fixed the single quote on index page issue#26

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 <h2>Welcome to the Performance engineering survey</h2>
 
 <div class="text">
-<h2>We’re interested in understanding the ecosystem and archetypes of the coliving movement, in order to make it easier to start and operate coliving houses, and to create a picture of the amazing spectrum of these spaces.
+<h2>We're interested in understanding the ecosystem and archetypes of the coliving movement, in order to make it easier to start and operate coliving houses, and to create a picture of the amazing spectrum of these spaces.
 
 There is more to performance engineering than just testing. Done right, performance engineering means understanding how all the parts of the system fit together, and building in performance from the first design. 
 </h2>


### PR DESCRIPTION
fixed #27  the 'We're' in index.js page to use the correct single quotation mark.
